### PR TITLE
Filters '*' routes from being included in the sitemap.

### DIFF
--- a/lib/expressSitemapHtml.js
+++ b/lib/expressSitemapHtml.js
@@ -103,7 +103,7 @@ function swaggerRoutes(app) {
  */
 function parseAndAddRouteParameters(endpoints) {
     endpoints
-        .filter(r => r.path != '*')
+        .filter(r => !r.path.includes('*'))
         .forEach(route => {
             const keys = []
             pathToRegexp(route.path, keys)

--- a/lib/expressSitemapHtml.js
+++ b/lib/expressSitemapHtml.js
@@ -103,6 +103,7 @@ function swaggerRoutes(app) {
  */
 function parseAndAddRouteParameters(endpoints) {
     endpoints
+        .filter(r => r.path != '*')
         .forEach(route => {
             const keys = []
             pathToRegexp(route.path, keys)


### PR DESCRIPTION
This causes an error with `path-to-regexp` module.