### PR TITLE
Fixed ParseRoutes and buildPrev for "Required" Express Router Modules

### DIFF
--- a/__tests__/expectedSwagger.json
+++ b/__tests__/expectedSwagger.json
@@ -151,6 +151,111 @@
                 "parameters": [],
                 "responses": {}
             }
+        },
+        "/api/cat": {
+          "get": {
+            "parameters": [],
+            "responses": {},
+            "tags": [
+              "vinyl"
+            ]
+          },
+          "post": {
+            "parameters": [],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "properties": {
+                      "cat": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "properties": {
+                      "cat": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "responses": {},
+            "tags": [
+              "vinyl"
+            ]
+          }
+        },
+        "/api/cat/{cat}": {
+          "delete": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "cat",
+                "required": "true"
+              }
+            ],
+            "responses": {},
+            "tags": [
+              "vinyl"
+            ]
+          },
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "cat",
+                "required": "true"
+              }
+            ],
+            "responses": {},
+            "tags": [
+              "vinyl"
+            ]
+          },
+          "put": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "cat",
+                "required": "true"
+              }
+            ],
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "properties": {
+                      "cat": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "properties": {
+                      "cat": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "responses": {},
+            "tags": [
+              "vinyl"
+            ]
+          }
         }
     }
 }

--- a/__tests__/expressSitemapHtmlParseRoutesTest.js
+++ b/__tests__/expressSitemapHtmlParseRoutesTest.js
@@ -24,11 +24,11 @@ const expected = [
     new Endpoint('get', '/duplicate', [duplicateGetHandler], '/api-docs/#/sitemap/get_duplicate'),
     new Endpoint('post', '/foo', [fooPostHandler], '/api-docs/#/sitemap/post_foo'),
     new Endpoint('put', '/noo', [nooPutHandler], '/api-docs/#/sitemap/put_noo'),
-    new Endpoint('get', '/api/cat', [(req, res) => {}], '/api-docs/#/sitemap/get_api_cat'),
-    new Endpoint('post', '/api/cat', [(req, res) => {console.log(`cat "${req.body.cat}" Created`)}], '/api-docs/#/sitemap/post_api_cat'),
-    new Endpoint('get', '/api/cat/{cat}', [(req, res) => {console.log(`Sending cat "${cat}"`)}], '/api-docs/#/sitemap/get_api_cat__cat_'),
-    new Endpoint('put', '/api/cat/{cat}', [(req, res) => {console.log(`cat "${cat}" Updated to: ${req.body.cat}`)}], '/api-docs/#/sitemap/put_api_cat__cat_'),
-    new Endpoint('delete', '/api/cat/{cat}', [(req, res) => {console.log(`cat "${req.params.cat}" Deleted`)}], '/api-docs/#/sitemap/delete_api_cat__cat_')
+    new Endpoint('get', '/api/cat', [apiCatGetAllHandler], '/api-docs/#/sitemap/get_api_cat'),
+    new Endpoint('post', '/api/cat', [apiCatPostHandler], '/api-docs/#/sitemap/post_api_cat'),
+    new Endpoint('get', '/api/cat/{cat}', [apiCatGetHandler], '/api-docs/#/sitemap/get_api_cat__cat_'),
+    new Endpoint('put', '/api/cat/{cat}', [apiCatPutHandler], '/api-docs/#/sitemap/put_api_cat__cat_'),
+    new Endpoint('delete', '/api/cat/{cat}', [apiCatDeleteHandler], '/api-docs/#/sitemap/delete_api_cat__cat_')
 ]
 
 test('Test sitemap', () => {
@@ -123,3 +123,28 @@ function duplicateGetByIdHandler(req, res) {}
 function duplicateGetHandler(req, res) {}
 function fooPostHandler(req, res) {}
 function nooPutHandler(req, res) {}
+
+function apiCatGetAllHandler(req, res) {
+    res.send(`cat`)
+}
+
+function apiCatPostHandler(req, res) {
+    console.log(`cat "${req.body.cat}" Created`)
+    res.send(`cat "${req.body.cat}" Created`)
+}
+
+function apiCatGetHandler(req, res) {
+    console.log(`Sending cat "${req.params.cat}"`)
+    res.send(req.params.cat)
+}
+
+function apiCatPutHandler(req, res) {
+    console.log(`cat "${req.params.cat}" Updated to:
+${req.body.cat}`)
+    res.send(`cat "${req.params.cat}" Updated`)
+}
+
+function apiCatDeleteHandler(req, res) {
+    console.log(`cat "${req.params.cat}" Deleted`)
+    res.send(`cat "${req.params.cat}" Deleted`)
+}

--- a/__tests__/expressSitemapHtmlParseRoutesTest.js
+++ b/__tests__/expressSitemapHtmlParseRoutesTest.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const handlebars = require('handlebars')
 const frisby = require('frisby')
 const sitemap = require('../index')
+const CatRouter = require('../example/routes/catRoutes')
 const Endpoint = sitemap.Endpoint
 /**
  * Expected results.
@@ -22,7 +23,12 @@ const expected = [
     new Endpoint('get', '/duplicate/{id}', [duplicateGetByIdHandler], '/api-docs/#/sitemap/get_duplicate__id_', ['id']),
     new Endpoint('get', '/duplicate', [duplicateGetHandler], '/api-docs/#/sitemap/get_duplicate'),
     new Endpoint('post', '/foo', [fooPostHandler], '/api-docs/#/sitemap/post_foo'),
-    new Endpoint('put', '/noo', [nooPutHandler], '/api-docs/#/sitemap/put_noo')
+    new Endpoint('put', '/noo', [nooPutHandler], '/api-docs/#/sitemap/put_noo'),
+    new Endpoint('get', '/api/cat', [(req, res) => {}], '/api-docs/#/sitemap/get_api_cat'),
+    new Endpoint('post', '/api/cat', [(req, res) => {console.log(`cat "${req.body.cat}" Created`)}], '/api-docs/#/sitemap/post_api_cat'),
+    new Endpoint('get', '/api/cat/{cat}', [(req, res) => {console.log(`Sending cat "${cat}"`)}], '/api-docs/#/sitemap/get_api_cat__cat_'),
+    new Endpoint('put', '/api/cat/{cat}', [(req, res) => {console.log(`cat "${cat}" Updated to: ${req.body.cat}`)}], '/api-docs/#/sitemap/put_api_cat__cat_'),
+    new Endpoint('delete', '/api/cat/{cat}', [(req, res) => {console.log(`cat "${req.params.cat}" Deleted`)}], '/api-docs/#/sitemap/delete_api_cat__cat_')
 ]
 
 test('Test sitemap', () => {
@@ -82,6 +88,7 @@ function setupWebApp() {
         .get('/duplicate', duplicateGetHandler)
         .post('/foo', fooPostHandler)
         .put('/noo', nooPutHandler)
+    app.use('/api/cat', CatRouter)
     return app
 }
 

--- a/example/app.js
+++ b/example/app.js
@@ -6,10 +6,12 @@ const express = require('express')
 const app = express()
 const core = new express.Router()
 const other = new express.Router()
+const CatRouter = require('./routes/catRoutes')
 app.use(express.urlencoded({extended: false}))
 app.use(express.json())
 app.use('/core', core)
 app.use(other)
+app.use('/api/cat', CatRouter)
 
 // express routing
 core.get('/', function(req, res) {

--- a/example/routes/catRoutes.js
+++ b/example/routes/catRoutes.js
@@ -1,0 +1,30 @@
+const express = require('express')
+const router = express.Router()
+
+router.get('/', function (req, res) {
+    res.send(`cat`)
+})
+
+router.post('/', function (req, res) {
+    console.log(`cat "${req.body.cat}" Created`)
+    res.send(`cat "${req.body.cat}" Created`)
+})
+
+
+router.get('/:cat', function (req, res) {
+    console.log(`Sending cat "${req.params.cat}"`)
+    res.send(req.params.cat)
+})
+
+router.put('/:cat', function (req, res) {
+    console.log(`cat "${req.params.cat}" Updated to:
+${req.body.cat}`)
+    res.send(`cat "${req.params.cat}" Updated`)
+})
+
+router.delete('/:cat', function (req, res) {
+    console.log(`cat "${req.params.cat}" Deleted`)
+    res.send(`cat "${req.params.cat}" Deleted`)
+})
+
+module.exports = router

--- a/example/routes/catRoutes.js
+++ b/example/routes/catRoutes.js
@@ -1,30 +1,37 @@
 const express = require('express')
 const router = express.Router()
 
-router.get('/', function (req, res) {
-    res.send(`cat`)
-})
+router.get('/', apiCatGetAllHandler)
+router.post('/', apiCatPostHandler)
+router.get('/:cat', apiCatGetHandler)
+router.put('/:cat', apiCatPutHandler)
+router.delete('/:cat', apiCatDeleteHandler)
 
-router.post('/', function (req, res) {
+
+
+function apiCatGetAllHandler(req, res) {
+    res.send(`cat`)
+}
+
+function apiCatPostHandler(req, res) {
     console.log(`cat "${req.body.cat}" Created`)
     res.send(`cat "${req.body.cat}" Created`)
-})
+}
 
-
-router.get('/:cat', function (req, res) {
+function apiCatGetHandler(req, res) {
     console.log(`Sending cat "${req.params.cat}"`)
     res.send(req.params.cat)
-})
+}
 
-router.put('/:cat', function (req, res) {
+function apiCatPutHandler(req, res) {
     console.log(`cat "${req.params.cat}" Updated to:
 ${req.body.cat}`)
     res.send(`cat "${req.params.cat}" Updated`)
-})
+}
 
-router.delete('/:cat', function (req, res) {
+function apiCatDeleteHandler(req, res) {
     console.log(`cat "${req.params.cat}" Deleted`)
     res.send(`cat "${req.params.cat}" Deleted`)
-})
+}
 
 module.exports = router

--- a/lib/expressSitemapHtml.js
+++ b/lib/expressSitemapHtml.js
@@ -184,6 +184,10 @@ function parseRoutes(app) {
      */
     routes.forEach(r => { if(!r.path.startsWith('/'))  r.path = '/' + r.path })
     /**
+     * Remove ending slash if present on every route
+     */
+     routes.forEach(r => { if(/(\/)$/g.test(r.path)) {r.path = r.path.replace(/(\/)$/g, '')} })
+    /**
      * Infer route parameters from path definition.
      */
     parseAndAddRouteParameters(routes)
@@ -232,7 +236,8 @@ function buildPrev(prev, regexp, path) {
     if(path) return prev + path
     regexp = regexp.toString().replace('/^\\/', '')
     regexp = regexp.replace('?(?=\\/|$)/i', '')
-    regexp = regexp.replace('\\/', '')
+    regexp = regexp.replace(/(\\\/)/g, '/')
+    regexp = regexp.replace(/(\/)$/g, '')
     regexp = regexp.replace('/^', '')
     return prev + regexp
 }


### PR DESCRIPTION
The code is working fine, but I am having trouble with 1 area of the tests... For some reason, the Expected endpoints are not populating their routeParams in __tests__/expressSitemapHtmlParseRoutesTest.js.

```
new Endpoint('get', '/api/cat', [apiCatGetAllHandler], '/api-docs/#/sitemap/get_api_cat'),
new Endpoint('post', '/api/cat', [apiCatPostHandler], '/api-docs/#/sitemap/post_api_cat'),
new Endpoint('get', '/api/cat/{cat}', [apiCatGetHandler], '/api-docs/#/sitemap/get_api_cat__cat_'),
new Endpoint('put', '/api/cat/{cat}', [apiCatPutHandler], '/api-docs/#/sitemap/put_api_cat__cat_'),
new Endpoint('delete', '/api/cat/{cat}', [apiCatDeleteHandler], '/api-docs/#/sitemap/delete_api_cat__cat_')
```

The first 2 work fine,as there are no routeParams, but the last 3 are giving errors:

![image](https://user-images.githubusercontent.com/77748753/118320828-60770500-b4c2-11eb-8000-df81f39e6d3a.png)
